### PR TITLE
Fix for broken notify metaparam

### DIFF
--- a/lib/puppet/provider/firewalld_zonefile/zoneprovider.rb
+++ b/lib/puppet/provider/firewalld_zonefile/zoneprovider.rb
@@ -211,6 +211,11 @@ Puppet::Type.type(:firewalld_zonefile).provide :zoneprovider, :parent => Puppet:
     file.close
     Puppet.debug "firewalld zonefile provider: Changes to #{path} configuration saved to disk."
     #Reload is now done from a notify command in the puppet code
+
+    # TEMPORARY - 
+    # We are doing `firewall-cmd --reload` here because we broke notify metaparam in 1.0.0 release on clients using a puppet master
+    # We will be fixing this breakage soon enough, but until then, this will suffice.
+    exec_firewall('--reload')
   end
 
   # Utilized code from crayfishx/puppet-firewalld as the firewall-cmd needs it's arguments properly formatted


### PR DESCRIPTION
We broke notify metaparam by using this provider method.  We will be fixing this in a near future release.
This patch allows `firewall-cmd --reload` to run inside the provider rather than rely on outside puppet code.
