### PR TITLE
Make require path relative

### DIFF
--- a/lib/puppet/provider/firewalld_direct/directprovider.rb
+++ b/lib/puppet/provider/firewalld_direct/directprovider.rb
@@ -1,5 +1,5 @@
 require 'puppet'
-require 'puppetx/firewalld/direct'
+require File.expand_path(File.join(File.dirname(__FILE__), '../../..', 'puppetx/firewalld/direct'))
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'firewalld'))
 require 'rexml/document'
 include REXML


### PR DESCRIPTION
I got an error from puppet about 'require' in our catalog tests

Could not autoload puppet/type/firewalld_direct: Could not autoload
puppet/provider/firewalld_direct/directprovider: cannot load such
file -- puppetx/firewalld/direct on node icts-t-kstest-1
