### PR TITLE
Fix extra whitespace inside rules and priority conversion

### DIFF
--- a/lib/puppet/provider/firewalld_direct/directprovider.rb
+++ b/lib/puppet/provider/firewalld_direct/directprovider.rb
@@ -56,13 +56,13 @@ Puppet::Type.type(:firewalld_direct).provide :directprovider do
                 'table' => e.attributes["table"].nil? ? nil : e.attributes["table"],
                 'chain' => e.attributes["chain"].nil? ? nil : e.attributes["chain"],
                 'priority' => e.attributes["priority"].nil? ? nil : e.attributes["priority"],
-                'args' => e.text.nil? ? nil : e.text,
+                'args' => e.text.nil? ? nil : e.text.strip.gsub(/[[:space:]]+/, ' '),
               }
             end
             if e.name == 'passthrough'
               passthroughs << {
                 'ipv' => e.attributes["ipv"].nil? ? nil : e.attributes['ipv'],
-                'args' => e.elements[0].nil? ? nil : e.elements[0],
+                'args' => e.elements[0].nil? ? nil : e.elements[0].strip.gsub(/[[:space:]]+/, ' '),
               }
             end
 

--- a/lib/puppet/type/firewalld_direct.rb
+++ b/lib/puppet/type/firewalld_direct.rb
@@ -120,7 +120,8 @@ Puppet::Type.newtype(:firewalld_direct) do
       # Here we deal with optional params and add them if they're not specified
       if rule and not rule.empty?
         rule['table'] ||= 'filter'
-        rule['priority'] ||= '0'
+        rule['priority'] = rule['priority'] ? rule['priority'].to_s : '0'
+        rule['args'] = rule['args'].strip.gsub(/[[:space:]]+/, ' ')
       end
       rule
     end


### PR DESCRIPTION
Firewallctl will split long lines and add `\n` and extra spaces. This
will try to fix this in both directions

Also, if you specify priority as an integer, this will now not reset
everytime (since firewallctl would show it as a string)
