### PR TITLE
Add width-fix to prevent the Pretty-formatter from wrapping long lines

### DIFF
--- a/lib/puppet/provider/firewalld_direct/directprovider.rb
+++ b/lib/puppet/provider/firewalld_direct/directprovider.rb
@@ -313,6 +313,7 @@ Puppet::Type.type(:firewalld_direct).provide :directprovider do
     file = File.open(filename, "w+")
     fmt = REXML::Formatters::Pretty.new
     fmt.compact = true
+    fmt.width = 1000
     fmt.write(doc, file)
     file.close
     Puppet.debug "firewalld directfile provider: Changes to #{filename} configuration saved to disk."

--- a/lib/puppet/provider/firewalld_zonefile/zoneprovider.rb
+++ b/lib/puppet/provider/firewalld_zonefile/zoneprovider.rb
@@ -207,6 +207,7 @@ Puppet::Type.type(:firewalld_zonefile).provide :zoneprovider, :parent => Puppet:
     file = File.open(path, "w+")
     fmt = REXML::Formatters::Pretty.new
     fmt.compact = true
+    fmt.width = 1000
     fmt.write(doc, file)
     file.close
     Puppet.debug "firewalld zonefile provider: Changes to #{path} configuration saved to disk."


### PR DESCRIPTION
This will prevent configurations like these:

``` xml
<?xml version='1.0' encoding='UTF-8'?>
<direct>
  <rule ipv='ipv6' table='filter' chain='FORWARD_direct' priority='0'>-m set --match-set chain-all src -m set --match-set chain-local dst -j ACCEPT</rule>
</direct>
```

being wrapped to be:

``` xml
<?xml version='1.0' encoding='UTF-8'?>
<direct>
  <rule ipv='ipv6' table='filter' chain='FORWARD_direct' priority='0'>
    -m set --match-set chain-all src -m set
    --match-set chain-local dst -j ACCEPT
  </rule>
</direct>
```

(firewalld-0.3.9-14.el7.noarch did not appreciate this)
