### PR TITLE
Added metaparams as per puppetlabs/concat

### DIFF
--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -409,7 +409,17 @@ Puppet::Type.newtype(:firewalld_zone) do
         file_opts[param] = self[param]
       end
     end
-      file_opts[:rich_rules] = self[:rich_rules] #unless self[:rich_rules].nil? or self[:rich_rules].empty?
+    file_opts[:rich_rules] = self[:rich_rules] #unless self[:rich_rules].nil? or self[:rich_rules].empty?
+
+    metaparams = Puppet::Type.metaparams
+    excluded_metaparams = [ :before, :notify, :require, :subscribe, :tag ]
+
+    metaparams.reject! { |param| excluded_metaparams.include? param }
+
+    metaparams.each do |metaparam|
+      file_opts[metaparam] = self[metaparam] if self[metaparam]
+    end
+
     [ Puppet::Type.type(:firewalld_zonefile).new(file_opts) ]
   end
 


### PR DESCRIPTION
(MODULES-3463) Properly passes metaparams to generated resource

This is to bring us in line with the bug found in puppetlabs/concat where the generated resource was not receiving the metaparams.
https://github.com/puppetlabs/puppetlabs-concat/commit/dd88b1a4eee853cfff60b99096c05ce85a9d556e
